### PR TITLE
Fix AsyncRequestNotification serialization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Pond5 Async Request Bundle
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
     branches: [ main ]
 

--- a/.phpstan/tests.neon
+++ b/.phpstan/tests.neon
@@ -7,6 +7,6 @@ parameters:
         - '#Method .* has no return typehint specified.#'
         - '#Call to an undefined method .*(Prophecy\\Prophecy\\ObjectProphecy|willThrow|willReturn)#'
         - '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy#'
-        - '#Cannot call method should(Not)?BeCalled(Once|Times)?\(\) on (void|bool)\.#'
+        - '#Cannot call method should(Not)?BeCalled(Once|Times)?\(\) on .*\.#'
         - '#Call to an undefined method .*::should(Not)?BeCalled(Once|Times)?\(\).#'
         - '#Parameter \#.* of .* expects .*, .*given#'

--- a/src/EventListener/AsyncRequestListener.php
+++ b/src/EventListener/AsyncRequestListener.php
@@ -55,7 +55,6 @@ class AsyncRequestListener implements EventSubscriberInterface
         if ($request->headers->get($this->asyncHeader) && in_array($request->getMethod(), $this->methods)) {
             $this->logger->debug('Received async request');
             $request->headers->remove($this->asyncHeader);
-            $request->getContent(); // read content from resource to have it serialized
             $this->bus->dispatch(new AsyncRequestNotification($request));
             $event->setResponse(new Response(null, Response::HTTP_ACCEPTED, ['Content-Type' => null]));
         }

--- a/src/Message/AsyncRequestNotification.php
+++ b/src/Message/AsyncRequestNotification.php
@@ -26,4 +26,21 @@ class AsyncRequestNotification
     {
         return $this->request;
     }
+
+    /**
+     * Message must be serializable while some attributes may contain e.g. Closures.
+     * Additionally, the body must be fetched from php://input before serialization (or it is lost).
+     * @see https://symfony.com/doc/current/messenger.html#creating-a-message-handler
+     * @return array
+     */
+    public function __serialize(): array
+    {
+        $this->request->getContent(); // read content from resource to have it serialized
+        // remove attributes
+        $request = $this->request->duplicate(null, null, []);
+
+        return [
+            'request' => $request,
+        ];
+    }
 }

--- a/tests/EventListener/AsyncRequestListenerTest.php
+++ b/tests/EventListener/AsyncRequestListenerTest.php
@@ -103,7 +103,6 @@ class AsyncRequestListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getMethod()->willReturn($method);
         $request->headers = $headerBag;
-        $request->getContent()->shouldBeCalled();
 
         $this->event->getRequest()->willReturn($request);
 
@@ -151,7 +150,6 @@ class AsyncRequestListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getMethod()->willReturn($method);
         $request->headers = $headerBag;
-        $request->getContent()->shouldNotBeCalled();
 
         $this->event->getRequest()->willReturn($request);
 
@@ -173,7 +171,6 @@ class AsyncRequestListenerTest extends TestCase
         $request = $this->prophesize(Request::class);
         $request->getMethod()->willReturn('PATCH');
         $request->headers = $headerBag;
-        $request->getContent()->shouldNotBeCalled();
 
         $this->event->getRequest()->willReturn($request);
 

--- a/tests/Message/AsyncRequestNotificationTest.php
+++ b/tests/Message/AsyncRequestNotificationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Message;
 use PHPUnit\Framework\TestCase;
 use Pond5\AsyncRequestBundle\Message\AsyncRequestNotification;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -14,11 +15,33 @@ class AsyncRequestNotificationTest extends TestCase
 {
     use ProphecyTrait;
 
+    /**
+     * @var Request|ObjectProphecy
+     */
+    private $request;
+
+    /**
+     * @var AsyncRequestNotification
+     */
+    private $asyncRequestNotification;
+
+    protected function setUp(): void
+    {
+        $this->request = $this->prophesize(Request::class);
+        $this->asyncRequestNotification = new AsyncRequestNotification($this->request->reveal());
+    }
+
     public function testSetGetRequest()
     {
-        $request = $this->prophesize(Request::class);
-        $asyncRequestNotification = new AsyncRequestNotification($request->reveal());
+        $this->assertSame($this->request->reveal(), $this->asyncRequestNotification->getRequest());
+    }
 
-        $this->assertSame($request->reveal(), $asyncRequestNotification->getRequest());
+    public function testSerialize()
+    {
+        $duplicatedRequest = $this->prophesize(Request::class);
+        $this->request->duplicate(null, null, [])->willReturn($duplicatedRequest->reveal());
+        $this->request->getContent()->shouldBeCalled();
+
+        $this->assertSame(['request' => $duplicatedRequest->reveal()], $this->asyncRequestNotification->__serialize());
     }
 }


### PR DESCRIPTION
`AsyncRequestNotification` must be serializable (https://symfony.com/doc/current/messenger.html#creating-a-message-handler) so `Request::attributes` is cleared as it may contain values that cannot be serialized, e.g. Closures.

The issue was discovered when trying to retry a request that threw an `\Error` exception that was not caught inside `HttpKernel::handle()` (https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/HttpKernel/HttpKernel.php#L75)